### PR TITLE
Feature: prompt dialect for MCP, capabilities list and exposed health…

### DIFF
--- a/mcp-adapter-flink/src/main/java/io/github/vaquarkhan/aegis/adapter/flink/FlinkAdapter.java
+++ b/mcp-adapter-flink/src/main/java/io/github/vaquarkhan/aegis/adapter/flink/FlinkAdapter.java
@@ -93,8 +93,9 @@ public final class FlinkAdapter implements EngineAdapter {
     public List<PromptDef> prompts(GatewayConfig cfg) {
         return List.of(
                 new PromptDef(
-                        "flink-sql-dialect",
-                        "Guidelines for writing streaming and batch queries using Flink SQL dialect"
+                        "flink-job-diagnostics",
+                        "Prompt template for inspecting Apache Flink job status and backpressure metrics",
+                        "Analyze the health of Flink job '{{jobId}}'. Check checkpoint completion rates, task manager liveness, and backpressure metrics across subtasks."
                 )
         );
     }

--- a/mcp-adapter-flink/src/main/java/io/github/vaquarkhan/aegis/adapter/flink/FlinkAdapter.java
+++ b/mcp-adapter-flink/src/main/java/io/github/vaquarkhan/aegis/adapter/flink/FlinkAdapter.java
@@ -3,12 +3,10 @@ package io.github.vaquarkhan.aegis.adapter.flink;
 import io.github.vaquarkhan.aegis.adapter.flink.client.SqlReadonlyGuard;
 import io.github.vaquarkhan.aegis.core.config.GatewayConfig;
 import io.github.vaquarkhan.aegis.core.observability.Metrics;
-import io.github.vaquarkhan.aegis.core.spi.CredentialResolver;
-import io.github.vaquarkhan.aegis.core.spi.EngineAdapter;
-import io.github.vaquarkhan.aegis.core.spi.PassThroughCredentialResolver;
-import io.github.vaquarkhan.aegis.core.spi.ReadOnlyGuard;
+import io.github.vaquarkhan.aegis.core.spi.*;
 import io.github.vaquarkhan.aegis.core.spi.ResourceDef;
 import io.github.vaquarkhan.aegis.core.spi.ToolDef;
+import io.github.vaquarkhan.aegis.core.spi.PromptDef;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -80,5 +78,24 @@ public final class FlinkAdapter implements EngineAdapter {
             factory = new FlinkToolFactory(cfg, sqlGuard, metrics);
         }
         return factory;
+    }
+    @Override
+    public boolean healthCheck(GatewayConfig cfg) {
+        return factory(cfg).isHealthy();
+    }
+
+    @Override
+    public Set<String> capabilities(GatewayConfig cfg) {
+        return Set.of("REST_API", "SQL_GATEWAY", "JAR_UPLOAD", "SAVEPOINTS");
+    }
+
+    @Override
+    public List<PromptDef> prompts(GatewayConfig cfg) {
+        return List.of(
+                new PromptDef(
+                        "flink-sql-dialect",
+                        "Guidelines for writing streaming and batch queries using Flink SQL dialect"
+                )
+        );
     }
 }

--- a/mcp-adapter-flink/src/main/java/io/github/vaquarkhan/aegis/adapter/flink/FlinkToolFactory.java
+++ b/mcp-adapter-flink/src/main/java/io/github/vaquarkhan/aegis/adapter/flink/FlinkToolFactory.java
@@ -186,6 +186,10 @@ public final class FlinkToolFactory {
         return b;
     }
 
+    public boolean isHealthy() {
+        return flink.ping() && gateway.ping();
+    }
+
     private String health() {
         boolean restOk = flink.ping();
         boolean gatewayOk = gateway.ping();

--- a/mcp-adapter-flink/src/test/java/io/github/vaquarkhan/aegis/adapter/flink/FlinkAdapterTest.java
+++ b/mcp-adapter-flink/src/test/java/io/github/vaquarkhan/aegis/adapter/flink/FlinkAdapterTest.java
@@ -2,6 +2,7 @@ package io.github.vaquarkhan.aegis.adapter.flink;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -10,6 +11,7 @@ import com.sun.net.httpserver.HttpServer;
 import io.github.vaquarkhan.aegis.adapter.flink.client.SqlReadonlyGuard;
 import io.github.vaquarkhan.aegis.core.config.GatewayConfig;
 import io.github.vaquarkhan.aegis.core.spi.CallContext;
+import io.github.vaquarkhan.aegis.core.spi.PromptDef;
 import io.github.vaquarkhan.aegis.core.spi.ResourceDef;
 import io.github.vaquarkhan.aegis.core.spi.ToolClass;
 import io.github.vaquarkhan.aegis.core.spi.ToolDef;
@@ -260,5 +262,19 @@ class FlinkAdapterTest {
                 .build();
         assertEquals("http://from-yaml:8081", FlinkConfigKeys.restUrl(cfg));
         assertEquals(Set.of("/opt/jars", "/srv/jars"), FlinkConfigKeys.jarUploadAllowDirs(cfg));
+    }
+
+    @Test
+    void prompts_returnsNonEmptyValidPromptList() {
+        FlinkEngineAdapter adapter = new FlinkEngineAdapter();
+        List<PromptDef> prompts = adapter.prompts();
+
+        assertNotNull(prompts, "Prompts list should not be null");
+        assertFalse(prompts.isEmpty(), "Flink adapter should provide at least one prompt");
+
+        PromptDef prompt = prompts.get(0);
+        assertEquals("flink-job-diagnostics", prompt.getId());
+        assertNotNull(prompt.getDescription());
+        assertFalse(prompt.getTemplate().isBlank(), "Prompt template must not be empty or blank");
     }
 }

--- a/mcp-gateway-core/src/main/java/io/github/vaquarkhan/aegis/core/boot/GatewayBootstrap.java
+++ b/mcp-gateway-core/src/main/java/io/github/vaquarkhan/aegis/core/boot/GatewayBootstrap.java
@@ -177,10 +177,12 @@ public final class GatewayBootstrap {
                 buildToolSpecs(exposedTools, exposure, chain, json, defaultCaller, resolvers);
         List<McpServerFeatures.SyncResourceSpecification> resourceSpecs =
                 buildResourceSpecs(aggregation.resources(), output, audit, defaultCaller);
-
+        List<McpServerFeatures.SyncPromptSpecification> promptSpecs =
+                buildPromptSpecs(adapters);
         McpSchema.ServerCapabilities caps = McpSchema.ServerCapabilities.builder()
                 .tools(true)
                 .resources(false, false)
+                .prompts(true)
                 .build();
 
         AtomicReference<Server> httpServer = new AtomicReference<>();
@@ -212,6 +214,7 @@ public final class GatewayBootstrap {
                     .capabilities(caps)
                     .tools(toolSpecs)
                     .resources(resourceSpecs)
+                    .prompts(promptSpecs)
                     .build();
             Server server = StreamableHttpTransport.start(
                     cfg.httpHost(),
@@ -231,6 +234,7 @@ public final class GatewayBootstrap {
                     .capabilities(caps)
                     .tools(toolSpecs)
                     .resources(resourceSpecs)
+                    .prompts(promptSpecs)
                     .build();
             StdioBoot.await();
         }
@@ -523,5 +527,35 @@ public final class GatewayBootstrap {
         } catch (Exception e) {
             // The binder may not be Logback, for example in tests. Leave the level alone.
         }
+    }
+
+    /** Aggregates prompt definitions across adapters into MCP server specifications. */
+    static List<McpServerFeatures.SyncPromptSpecification> buildPromptSpecs(List<EngineAdapter> adapters) {
+        List<McpServerFeatures.SyncPromptSpecification> promptSpecs = new ArrayList<>();
+
+        for (EngineAdapter adapter : adapters) {
+            if (adapter.prompts() == null) {
+                continue;
+            }
+            for (io.github.vaquarkhan.aegis.core.spi.PromptDef def : adapter.prompts()) {
+                McpSchema.Prompt prompt = McpSchema.Prompt.builder()
+                        .name(def.id())
+                        .description(def.description())
+                        .build();
+
+                promptSpecs.add(McpServerFeatures.SyncPromptSpecification.builder()
+                        .prompt(prompt)
+                        .getHandler((exchange, request) -> new McpSchema.GetPromptResult(
+                                def.description(),
+                                List.of(new McpSchema.PromptMessage(
+                                        McpSchema.Role.USER,
+                                        new McpSchema.TextContent(def.template())
+                                ))
+                        ))
+                        .build());
+            }
+        }
+        LOG.info("registered prompts={}", promptSpecs.size());
+        return promptSpecs;
     }
 }

--- a/mcp-gateway-core/src/main/java/io/github/vaquarkhan/aegis/core/spi/EngineAdapter.java
+++ b/mcp-gateway-core/src/main/java/io/github/vaquarkhan/aegis/core/spi/EngineAdapter.java
@@ -45,21 +45,6 @@ public interface EngineAdapter {
     Set<String> egressAllowHosts(GatewayConfig cfg);
 
     /**
-     * Direct operational health probe for the gateway/router to verify backend liveness.
-     */
-    default boolean healthCheck(GatewayConfig cfg) {
-        return true;
-    }
-
-    /**
-     * Set of operational capabilities enabled on the connected cluster
-     * (e.g., {@code REST_API}, {@code SQL_GATEWAY}, {@code JAR_UPLOAD}).
-     */
-    default Set<String> capabilities(GatewayConfig cfg) {
-        return Set.of();
-    }
-
-    /**
      * Dialect-specific system prompts attached to MCP context for LLM guidance.
      */
     default List<PromptDef> prompts(GatewayConfig cfg) {

--- a/mcp-gateway-core/src/main/java/io/github/vaquarkhan/aegis/core/spi/EngineAdapter.java
+++ b/mcp-gateway-core/src/main/java/io/github/vaquarkhan/aegis/core/spi/EngineAdapter.java
@@ -43,4 +43,26 @@ public interface EngineAdapter {
      * {@code MCP_GW_EGRESS_ALLOW_HOSTS}; anything outside the union is denied at step 5.
      */
     Set<String> egressAllowHosts(GatewayConfig cfg);
+
+    /**
+     * Direct operational health probe for the gateway/router to verify backend liveness.
+     */
+    default boolean healthCheck(GatewayConfig cfg) {
+        return true;
+    }
+
+    /**
+     * Set of operational capabilities enabled on the connected cluster
+     * (e.g., {@code REST_API}, {@code SQL_GATEWAY}, {@code JAR_UPLOAD}).
+     */
+    default Set<String> capabilities(GatewayConfig cfg) {
+        return Set.of();
+    }
+
+    /**
+     * Dialect-specific system prompts attached to MCP context for LLM guidance.
+     */
+    default List<PromptDef> prompts(GatewayConfig cfg) {
+        return List.of();
+    }
 }

--- a/mcp-gateway-core/src/main/java/io/github/vaquarkhan/aegis/core/spi/PromptDef.java
+++ b/mcp-gateway-core/src/main/java/io/github/vaquarkhan/aegis/core/spi/PromptDef.java
@@ -12,7 +12,7 @@ public final class PromptDef {
     private final String description;
     private final String template;
 
-    PromptDef(
+    public PromptDef(
             String id,
             String description,
             String template

--- a/mcp-gateway-core/src/main/java/io/github/vaquarkhan/aegis/core/spi/PromptDef.java
+++ b/mcp-gateway-core/src/main/java/io/github/vaquarkhan/aegis/core/spi/PromptDef.java
@@ -1,0 +1,63 @@
+package io.github.vaquarkhan.aegis.core.spi;
+
+
+import java.util.Objects;
+
+/**
+ * Definition of an engine-specific prompt or system instruction template.
+ * Passed back via EngineAdapter.prompts() to provide dialect & operational guidance to LLMs.
+ */
+public final class PromptDef {
+    private final String id;
+    private final String description;
+    private final String template;
+
+    PromptDef(
+            String id,
+            String description,
+            String template
+    ) {
+        this.id = id;
+        this.description = description;
+        this.template = template;
+    }
+
+    public String id() {
+        return id;
+    }
+
+    public String description() {
+        return description;
+    }
+
+    public String template() {
+        return template;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        var that = (PromptDef) obj;
+        return Objects.equals(this.id, that.id) &&
+                Objects.equals(this.description, that.description) &&
+                Objects.equals(this.template, that.template);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, description, template);
+    }
+
+    @Override
+    public String toString() {
+        return "PromptDef[" +
+                "id=" + id + ", " +
+                "description=" + description + ", " +
+                "template=" + template + ']';
+    }
+
+    public PromptDef(String id, String description) {
+        this(id, description, "");
+    }
+}

--- a/mcp-gateway-core/src/test/java/io/github/vaquarkhan/aegis/core/PromptAggregationTest.java
+++ b/mcp-gateway-core/src/test/java/io/github/vaquarkhan/aegis/core/PromptAggregationTest.java
@@ -1,0 +1,58 @@
+package io.github.vaquarkhan.aegis.core.spi;
+
+import io.github.vaquarkhan.aegis.core.config.GatewayConfig;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PromptAggregationTest {
+
+    static class MockAdapter implements EngineAdapter {
+        @Override
+        public String engineId() {
+            return "mock";
+        }
+
+        @Override
+        public String taxonomyClass() {
+            return "mock-taxonomy";
+        }
+
+        @Override
+        public List<ToolDef> tools(GatewayConfig cfg) {
+            return List.of();
+        }
+
+        @Override
+        public List<ResourceDef> resources(GatewayConfig cfg) {
+            return List.of();
+        }
+
+        @Override
+        public Set<String> egressAllowHosts(GatewayConfig cfg) {
+            return Set.of();
+        }
+
+        @Override
+        public List<PromptDef> prompts(GatewayConfig cfg) {
+            return List.of(new PromptDef("mock-prompt", "Mock Desc", "Mock Template Content"));
+        }
+    }
+
+    @Test
+    void aggregatePrompts_collectsPromptsFromAllAdapters() {
+        List<EngineAdapter> adapters = List.of(new MockAdapter());
+        GatewayConfig config = GatewayConfig.builder().defaults().build();
+
+        List<PromptDef> aggregated = adapters.stream()
+                .flatMap(a -> a.prompts(config).stream())
+                .toList();
+
+        assertEquals(1, aggregated.size());
+        assertEquals("mock-prompt", aggregated.get(0).getId());
+        assertEquals("Mock Template Content", aggregated.get(0).getTemplate());
+    }
+}


### PR DESCRIPTION

###  feat(spi): add prompts to `EngineAdapter`

Extends the `EngineAdapter` SPI with three backward-compatible `default` methods to support gateway-level operations and LLM guidance:

* **`prompts(cfg)`**: Introduces `PromptDef` to inject engine-specific system prompts (e.g., Flink SQL rules) into LLM context.

**Changes:**

* Added `PromptDef` and default SPI methods in `mcp-core`.
* Implemented `healthCheck`, `capabilities`, and `prompts` in `mcp-adapter-flink`.

Details on the functions:

## Function Overview

| Function | Primary Layer Served | Core Purpose | Impact on System |
|----------|----------------------|--------------|------------------|
| `prompts()` | LLM Context Manager | Engine dialect guidance | Reduces query syntax errors and minimizes retry loops by providing engine-specific prompt guidance. |