### PR TITLE
test(core): drop redundant CallContext cast in null-context test

### DIFF
--- a/mcp-gateway-core/src/test/java/io/github/vaquarkhan/aegis/core/PolicyDecisionPointTest.java
+++ b/mcp-gateway-core/src/test/java/io/github/vaquarkhan/aegis/core/PolicyDecisionPointTest.java
@@ -80,7 +80,7 @@ class PolicyDecisionPointTest {
 
     @Test
     void nullContextIsDeniedEvenByAPermissiveEngine() {
-        assertFalse(PolicyDecisionPoint.allowAll().allows((CallContext) null));
+        assertFalse(PolicyDecisionPoint.allowAll().allows(null));
         assertTrue(PolicyDecisionPoint.allowAll().allows(ops(), "anything", Map.of()));
     }
 }


### PR DESCRIPTION
fix Casting 'null' to is redundant.