### PR TITLE
use Jackson to write JSON (Solr and Spark only)

### DIFF
--- a/mcp-adapter-solr/pom.xml
+++ b/mcp-adapter-solr/pom.xml
@@ -22,6 +22,10 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>tools.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>

--- a/mcp-adapter-solr/src/main/java/io/github/vaquarkhan/aegis/adapter/solr/SolrAdapter.java
+++ b/mcp-adapter-solr/src/main/java/io/github/vaquarkhan/aegis/adapter/solr/SolrAdapter.java
@@ -1,6 +1,8 @@
 package io.github.vaquarkhan.aegis.adapter.solr;
 
 import io.github.vaquarkhan.aegis.core.config.GatewayConfig;
+import io.github.vaquarkhan.aegis.core.jsonschema.InputSchema;
+import io.github.vaquarkhan.aegis.core.jsonschema.SchemaProperties;
 import io.github.vaquarkhan.aegis.core.spi.CallContext;
 import io.github.vaquarkhan.aegis.core.spi.EngineAdapter;
 import io.github.vaquarkhan.aegis.core.spi.ResourceDef;
@@ -8,6 +10,7 @@ import io.github.vaquarkhan.aegis.core.spi.ToolClass;
 import io.github.vaquarkhan.aegis.core.spi.ToolDef;
 import io.github.vaquarkhan.aegis.core.util.HttpJsonClient;
 import io.github.vaquarkhan.aegis.core.util.Inputs;
+import io.github.vaquarkhan.aegis.core.util.JacksonUtils;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -37,16 +40,16 @@ public final class SolrAdapter implements EngineAdapter {
         HttpJsonClient client = new HttpJsonClient(baseUrl(cfg));
         List<ToolDef> tools = new ArrayList<>();
         tools.add(tool("system_info", ToolClass.READ, "Solr system info",
-                "{\"type\":\"object\",\"properties\":{}}",
+                new InputSchema("object", SchemaProperties.empty(), null),
                 ctx -> client.get("/admin/info/system?wt=json")));
         tools.add(tool("list_collections", ToolClass.READ, "List Solr collections",
-                "{\"type\":\"object\",\"properties\":{}}",
+                new InputSchema("object", SchemaProperties.empty(), null),
                 ctx -> client.get("/admin/collections?action=LIST&wt=json")));
         tools.add(tool("query", ToolClass.READ, "Query a Solr collection",
-                "{\"type\":\"object\",\"properties\":{\"collection\":{\"type\":\"string\"},\"q\":{\"type\":\"string\"}},\"required\":[\"collection\",\"q\"]}",
+                new InputSchema("object", SchemaProperties.collectionAndQ(), List.of("collection", "q")),
                 ctx -> client.get("/" + Inputs.requireId(arg(ctx, "collection")) + "/select?q=" + Inputs.requirePath(arg(ctx, "q") == null || arg(ctx, "q").isBlank() ? "*:*" : arg(ctx, "q")) + "&wt=json")));
         tools.add(tool("delete_collection", ToolClass.DESTRUCTIVE, "Delete a Solr collection",
-                "{\"type\":\"object\",\"properties\":{\"collection\":{\"type\":\"string\"},\"approvalToken\":{\"type\":\"string\"}},\"required\":[\"collection\",\"approvalToken\"]}",
+                new InputSchema("object", SchemaProperties.collectionAndApprovalToken(), List.of("collection", "approvalToken")),
                 ctx -> client.get("/admin/collections?action=DELETE&name=" + Inputs.requireId(arg(ctx, "collection")) + "&wt=json")));
         return tools;
     }
@@ -77,9 +80,13 @@ public final class SolrAdapter implements EngineAdapter {
                 cfg.adapterProperty("SOLR_URL", "http://localhost:8983/solr"));
     }
 
-    private static ToolDef tool(String name, ToolClass cls, String desc, String schema,
+    private static ToolDef tool(String name, ToolClass cls, String desc, InputSchema schema,
                                 Function<CallContext, String> backend) {
-        return new ToolDef(name, cls, desc, schema, backend);
+        try {
+            return new ToolDef(name, cls, desc, JacksonUtils.getMapper().writeValueAsString(schema), backend);
+        } catch (tools.jackson.core.JacksonException e) {
+            throw new IllegalStateException("Failed to serialize schema for tool: " + name, e);
+        }
     }
 
     private static String arg(CallContext ctx, String key) {

--- a/mcp-adapter-solr/src/test/java/io/github/vaquarkhan/aegis/adapter/solr/SolrAdapterTest.java
+++ b/mcp-adapter-solr/src/test/java/io/github/vaquarkhan/aegis/adapter/solr/SolrAdapterTest.java
@@ -1,16 +1,25 @@
 package io.github.vaquarkhan.aegis.adapter.solr;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.vaquarkhan.aegis.core.config.GatewayConfig;
+import io.github.vaquarkhan.aegis.core.jsonschema.InputSchema;
+import io.github.vaquarkhan.aegis.core.jsonschema.SchemaProperties;
 import io.github.vaquarkhan.aegis.core.spi.ToolDef;
+import io.github.vaquarkhan.aegis.core.util.JacksonUtils;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 /** @author Viquar Khan */
 class SolrAdapterTest {
+
+    private static final ObjectMapper MAPPER = JacksonUtils.getMapper();
 
     @Test
     void taxonomyAndTools() {
@@ -22,4 +31,51 @@ class SolrAdapterTest {
                 .collect(Collectors.toSet());
         assertTrue(names.contains("system_info"));
     }
+
+    @Test
+    void emptySchemaSerializesCorrectly() throws Exception {
+        InputSchema schema = new InputSchema("object", SchemaProperties.empty(), null);
+        String json = MAPPER.writeValueAsString(schema);
+        JsonNode node = MAPPER.readTree(json);
+
+        assertEquals("object", node.get("type").asText());
+        assertTrue(node.get("properties").isObject());
+        assertTrue(node.get("properties").isEmpty());
+        assertFalse(node.has("required"));
+    }
+
+    @Test
+    void querySchemaSerializesCorrectly() throws Exception {
+        InputSchema schema = new InputSchema("object",
+                SchemaProperties.collectionAndQ(),
+                List.of("collection", "q"));
+        String json = MAPPER.writeValueAsString(schema);
+        JsonNode node = MAPPER.readTree(json);
+
+        assertEquals("object", node.get("type").asText());
+        assertEquals("string", node.get("properties").get("collection").get("type").asText());
+        assertEquals("string", node.get("properties").get("q").get("type").asText());
+        assertFalse(node.get("properties").has("approvalToken"));
+        assertEquals(2, node.get("required").size());
+        assertEquals("collection", node.get("required").get(0).asText());
+        assertEquals("q", node.get("required").get(1).asText());
+    }
+
+    @Test
+    void deleteCollectionSchemaSerializesCorrectly() throws Exception {
+        InputSchema schema = new InputSchema("object",
+                SchemaProperties.collectionAndApprovalToken(),
+                List.of("collection", "approvalToken"));
+        String json = MAPPER.writeValueAsString(schema);
+        JsonNode node = MAPPER.readTree(json);
+
+        assertEquals("object", node.get("type").asText());
+        assertEquals("string", node.get("properties").get("collection").get("type").asText());
+        assertEquals("string", node.get("properties").get("approvalToken").get("type").asText());
+        assertFalse(node.get("properties").has("q"));
+        assertEquals(2, node.get("required").size());
+        assertEquals("collection", node.get("required").get(0).asText());
+        assertEquals("approvalToken", node.get("required").get(1).asText());
+    }
+
 }

--- a/mcp-adapter-spark/pom.xml
+++ b/mcp-adapter-spark/pom.xml
@@ -22,6 +22,10 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>tools.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>

--- a/mcp-adapter-spark/src/main/java/io/github/vaquarkhan/aegis/adapter/spark/SparkAdapter.java
+++ b/mcp-adapter-spark/src/main/java/io/github/vaquarkhan/aegis/adapter/spark/SparkAdapter.java
@@ -2,6 +2,10 @@ package io.github.vaquarkhan.aegis.adapter.spark;
 
 import io.github.vaquarkhan.aegis.core.config.GatewayConfig;
 import io.github.vaquarkhan.aegis.core.governance.SqlReadonlyGuard;
+import io.github.vaquarkhan.aegis.core.jsonschema.InputSchema;
+import io.github.vaquarkhan.aegis.core.jsonschema.SchemaProperties;
+import io.github.vaquarkhan.aegis.core.jsonschema.SqlRequest;
+import io.github.vaquarkhan.aegis.core.jsonschema.SubmitRequest;
 import io.github.vaquarkhan.aegis.core.spi.CallContext;
 import io.github.vaquarkhan.aegis.core.spi.CredentialResolver;
 import io.github.vaquarkhan.aegis.core.spi.EngineAdapter;
@@ -11,6 +15,7 @@ import io.github.vaquarkhan.aegis.core.spi.ResourceDef;
 import io.github.vaquarkhan.aegis.core.spi.ToolClass;
 import io.github.vaquarkhan.aegis.core.spi.ToolDef;
 import io.github.vaquarkhan.aegis.core.util.Inputs;
+import io.github.vaquarkhan.aegis.core.util.JacksonUtils;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
@@ -54,13 +59,13 @@ public final class SparkAdapter implements EngineAdapter {
         SparkHttpClient sql = sqlUrl == null ? null : new SparkHttpClient(sqlUrl);
         List<ToolDef> tools = new ArrayList<>();
         tools.add(tool("list_applications", ToolClass.READ, "List Spark History applications",
-                "{\"type\":\"object\",\"properties\":{}}",
+                new InputSchema("object", SchemaProperties.empty(), null),
                 ctx -> history.get("/api/v1/applications")));
         tools.add(tool("get_application", ToolClass.READ, "Get Spark application details from History Server",
-                "{\"type\":\"object\",\"properties\":{\"appId\":{\"type\":\"string\"}},\"required\":[\"appId\"]}",
+                new InputSchema("object", SchemaProperties.appIdOnly(), List.of("appId")),
                 ctx -> history.get("/api/v1/applications/" + Inputs.requireId(arg(ctx, "appId")))));
         tools.add(tool("run_sql_readonly", ToolClass.READ, "Guarded read-only SQL via HTTP SQL gateway",
-                "{\"type\":\"object\",\"properties\":{\"sql\":{\"type\":\"string\"}},\"required\":[\"sql\"]}",
+                new InputSchema("object", SchemaProperties.sqlOnly(), List.of("sql")),
                 ctx -> {
                     String sqlText = Inputs.requireSql(arg(ctx, "sql"), cfg.maxSqlChars());
                     if (!sqlGuard.isReadOnly(sqlText)) {
@@ -71,13 +76,13 @@ public final class SparkAdapter implements EngineAdapter {
                                 "SQL_BACKEND_NOT_CONFIGURED: set spark.sql.http.url or SPARK_SQL_HTTP_URL to a "
                                         + "read-only SQL endpoint; Spark Connect and Thrift clients are not bundled");
                     }
-                    return sql.post("", "{\"sql\":\"" + Inputs.jsonEscape(sqlText) + "\"}");
+                    return sql.post("", JacksonUtils.getMapper().writeValueAsString(new SqlRequest(sqlText)));
                 }));
         tools.add(tool("submit_batch", ToolClass.DESTRUCTIVE, "Submit a Livy batch job",
-                "{\"type\":\"object\",\"properties\":{\"file\":{\"type\":\"string\"},\"className\":{\"type\":\"string\"},\"approvalToken\":{\"type\":\"string\"}},\"required\":[\"file\",\"approvalToken\"]}",
+                new InputSchema("object", SchemaProperties.fileClassNameAndApprovalToken(), List.of("file", "approvalToken")),
                 ctx -> livy.post("/batches", submitBody(ctx))));
         tools.add(tool("kill_application", ToolClass.DESTRUCTIVE, "Kill a Livy batch application",
-                "{\"type\":\"object\",\"properties\":{\"appId\":{\"type\":\"string\"},\"approvalToken\":{\"type\":\"string\"}},\"required\":[\"appId\",\"approvalToken\"]}",
+                new InputSchema("object", SchemaProperties.appIdAndApprovalToken(), List.of("appId", "approvalToken")),
                 ctx -> livy.delete("/batches/" + Inputs.requireId(arg(ctx, "appId")))));
         return tools;
     }
@@ -131,12 +136,15 @@ public final class SparkAdapter implements EngineAdapter {
     /** Livy batch request body. Only the fields the caller supplied are sent. */
     private static String submitBody(CallContext ctx) {
         String file = requireFileRef(arg(ctx, "file"));
-        StringBuilder sb = new StringBuilder("{\"file\":\"").append(Inputs.jsonEscape(file)).append('"');
         String className = arg(ctx, "className");
         if (className != null && !className.isBlank()) {
-            sb.append(",\"className\":\"").append(Inputs.jsonEscape(Inputs.requireId(className))).append('"');
+            className = Inputs.requireId(className);
         }
-        return sb.append('}').toString();
+        try {
+            return JacksonUtils.getMapper().writeValueAsString(new SubmitRequest(file, className));
+        } catch (tools.jackson.core.JacksonException e) {
+            throw new IllegalStateException("Failed to serialize Livy submit body", e);
+        }
     }
 
     /**
@@ -172,9 +180,13 @@ public final class SparkAdapter implements EngineAdapter {
         }
     }
 
-    private static ToolDef tool(String name, ToolClass cls, String desc, String schema,
+    private static ToolDef tool(String name, ToolClass cls, String desc, InputSchema schema,
                                 Function<CallContext, String> backend) {
-        return new ToolDef(name, cls, desc, schema, backend);
+        try {
+            return new ToolDef(name, cls, desc, JacksonUtils.getMapper().writeValueAsString(schema), backend);
+        } catch (tools.jackson.core.JacksonException e) {
+            throw new IllegalStateException("Failed to serialize schema for tool: " + name, e);
+        }
     }
 
     private static String arg(CallContext ctx, String key) {

--- a/mcp-adapter-spark/src/main/java/io/github/vaquarkhan/aegis/adapter/spark/SparkAdapter.java
+++ b/mcp-adapter-spark/src/main/java/io/github/vaquarkhan/aegis/adapter/spark/SparkAdapter.java
@@ -76,7 +76,11 @@ public final class SparkAdapter implements EngineAdapter {
                                 "SQL_BACKEND_NOT_CONFIGURED: set spark.sql.http.url or SPARK_SQL_HTTP_URL to a "
                                         + "read-only SQL endpoint; Spark Connect and Thrift clients are not bundled");
                     }
-                    return sql.post("", JacksonUtils.getMapper().writeValueAsString(new SqlRequest(sqlText)));
+                    try {
+                        return sql.post("", JacksonUtils.getMapper().writeValueAsString(new SqlRequest(sqlText)));
+                    } catch (tools.jackson.core.JacksonException e) {
+                        throw new IllegalStateException("Failed to serialize SQL request body", e);
+                    }
                 }));
         tools.add(tool("submit_batch", ToolClass.DESTRUCTIVE, "Submit a Livy batch job",
                 new InputSchema("object", SchemaProperties.fileClassNameAndApprovalToken(), List.of("file", "approvalToken")),
@@ -137,7 +141,9 @@ public final class SparkAdapter implements EngineAdapter {
     private static String submitBody(CallContext ctx) {
         String file = requireFileRef(arg(ctx, "file"));
         String className = arg(ctx, "className");
-        if (className != null && !className.isBlank()) {
+        if (className == null || className.isBlank()) {
+            className = null;
+        } else {
             className = Inputs.requireId(className);
         }
         try {

--- a/mcp-adapter-spark/src/test/java/io/github/vaquarkhan/aegis/adapter/spark/SparkAdapterTest.java
+++ b/mcp-adapter-spark/src/test/java/io/github/vaquarkhan/aegis/adapter/spark/SparkAdapterTest.java
@@ -1,6 +1,7 @@
 package io.github.vaquarkhan.aegis.adapter.spark;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -8,10 +9,15 @@ import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
 import io.github.vaquarkhan.aegis.core.auth.CallerIdentity;
 import io.github.vaquarkhan.aegis.core.config.GatewayConfig;
+import io.github.vaquarkhan.aegis.core.jsonschema.InputSchema;
+import io.github.vaquarkhan.aegis.core.jsonschema.SchemaProperties;
+import io.github.vaquarkhan.aegis.core.jsonschema.SqlRequest;
+import io.github.vaquarkhan.aegis.core.jsonschema.SubmitRequest;
 import io.github.vaquarkhan.aegis.core.spi.CallContext;
 import io.github.vaquarkhan.aegis.core.spi.ToolClass;
 import io.github.vaquarkhan.aegis.core.spi.ToolDef;
 import io.github.vaquarkhan.aegis.core.util.Inputs;
+import io.github.vaquarkhan.aegis.core.util.JacksonUtils;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
@@ -23,6 +29,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 /** @author Viquar Khan */
 class SparkAdapterTest {
@@ -183,6 +191,94 @@ class SparkAdapterTest {
         } finally {
             server.stop(0);
         }
+    }
+
+    private static final ObjectMapper MAPPER = JacksonUtils.getMapper();
+
+    @Test
+    void emptySchemaSerializesCorrectly() throws Exception {
+        InputSchema schema = new InputSchema("object", SchemaProperties.empty(), null);
+        JsonNode node = MAPPER.readTree(MAPPER.writeValueAsString(schema));
+
+        assertEquals("object", node.get("type").asText());
+        assertTrue(node.get("properties").isEmpty());
+        assertFalse(node.has("required"));
+    }
+
+    @Test
+    void getApplicationSchemaSerializesCorrectly() throws Exception {
+        InputSchema schema = new InputSchema("object", SchemaProperties.appIdOnly(), List.of("appId"));
+        JsonNode node = MAPPER.readTree(MAPPER.writeValueAsString(schema));
+
+        assertEquals("object", node.get("type").asText());
+        assertEquals("string", node.get("properties").get("appId").get("type").asText());
+        assertEquals(1, node.get("properties").size());
+        assertEquals(1, node.get("required").size());
+        assertEquals("appId", node.get("required").get(0).asText());
+    }
+
+    @Test
+    void runSqlReadonlySchemaSerializesCorrectly() throws Exception {
+        InputSchema schema = new InputSchema("object", SchemaProperties.sqlOnly(), List.of("sql"));
+        JsonNode node = MAPPER.readTree(MAPPER.writeValueAsString(schema));
+
+        assertEquals("object", node.get("type").asText());
+        assertEquals("string", node.get("properties").get("sql").get("type").asText());
+        assertEquals(1, node.get("properties").size());
+        assertEquals("sql", node.get("required").get(0).asText());
+    }
+
+    @Test
+    void submitBatchSchemaSerializesCorrectly() throws Exception {
+        InputSchema schema = new InputSchema("object",
+                SchemaProperties.fileClassNameAndApprovalToken(), List.of("file", "approvalToken"));
+        JsonNode node = MAPPER.readTree(MAPPER.writeValueAsString(schema));
+
+        assertEquals("object", node.get("type").asText());
+        assertEquals("string", node.get("properties").get("file").get("type").asText());
+        assertEquals("string", node.get("properties").get("className").get("type").asText());
+        assertEquals("string", node.get("properties").get("approvalToken").get("type").asText());
+        assertEquals(3, node.get("properties").size());
+        assertEquals(2, node.get("required").size());
+        assertEquals("file", node.get("required").get(0).asText());
+        assertEquals("approvalToken", node.get("required").get(1).asText());
+    }
+
+    @Test
+    void killApplicationSchemaSerializesCorrectly() throws Exception {
+        InputSchema schema = new InputSchema("object",
+                SchemaProperties.appIdAndApprovalToken(), List.of("appId", "approvalToken"));
+        JsonNode node = MAPPER.readTree(MAPPER.writeValueAsString(schema));
+
+        assertEquals("object", node.get("type").asText());
+        assertEquals("string", node.get("properties").get("appId").get("type").asText());
+        assertEquals("string", node.get("properties").get("approvalToken").get("type").asText());
+        assertEquals(2, node.get("properties").size());
+        assertEquals("appId", node.get("required").get(0).asText());
+        assertEquals("approvalToken", node.get("required").get(1).asText());
+    }
+
+    @Test
+    void submitRequestSerializesWithClassName() throws Exception {
+        JsonNode node = MAPPER.readTree(MAPPER.writeValueAsString(new SubmitRequest("s3a://jobs/etl.jar", "com.example.Etl")));
+
+        assertEquals("s3a://jobs/etl.jar", node.get("file").asText());
+        assertEquals("com.example.Etl", node.get("className").asText());
+    }
+
+    @Test
+    void submitRequestOmitsNullClassName() throws Exception {
+        JsonNode node = MAPPER.readTree(MAPPER.writeValueAsString(new SubmitRequest("s3a://jobs/etl.jar", null)));
+
+        assertEquals("s3a://jobs/etl.jar", node.get("file").asText());
+        assertFalse(node.has("className"));
+    }
+
+    @Test
+    void sqlRequestSerializesCorrectly() throws Exception {
+        JsonNode node = MAPPER.readTree(MAPPER.writeValueAsString(new SqlRequest("select 1")));
+
+        assertEquals("select 1", node.get("sql").asText());
     }
 
     private static GatewayConfig livyConfig(int port) {

--- a/mcp-gateway-core/pom.xml
+++ b/mcp-gateway-core/pom.xml
@@ -43,6 +43,7 @@
     <dependency>
       <groupId>tools.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.nimbusds</groupId>

--- a/mcp-gateway-core/pom.xml
+++ b/mcp-gateway-core/pom.xml
@@ -41,6 +41,10 @@
       <artifactId>snakeyaml</artifactId>
     </dependency>
     <dependency>
+      <groupId>tools.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.nimbusds</groupId>
       <artifactId>nimbus-jose-jwt</artifactId>
     </dependency>

--- a/mcp-gateway-core/src/main/java/io/github/vaquarkhan/aegis/core/jsonschema/InputSchema.java
+++ b/mcp-gateway-core/src/main/java/io/github/vaquarkhan/aegis/core/jsonschema/InputSchema.java
@@ -1,0 +1,11 @@
+package io.github.vaquarkhan.aegis.core.jsonschema;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.util.List;
+
+/**
+ * A JSON Schema {@code inputSchema} object with {@code type}, {@code properties}, and optional {@code required}.
+ */
+@JsonPropertyOrder({"type", "properties", "required"})
+public record InputSchema(String type, SchemaProperties properties, List<String> required) {
+}

--- a/mcp-gateway-core/src/main/java/io/github/vaquarkhan/aegis/core/jsonschema/SchemaProperties.java
+++ b/mcp-gateway-core/src/main/java/io/github/vaquarkhan/aegis/core/jsonschema/SchemaProperties.java
@@ -1,0 +1,48 @@
+package io.github.vaquarkhan.aegis.core.jsonschema;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Strongly-typed JSON Schema {@code properties} object.
+ * Each field is an optional property definition; null fields are omitted from serialized output.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record SchemaProperties(
+        StringProperty appId,
+        StringProperty approvalToken,
+        StringProperty className,
+        StringProperty collection,
+        StringProperty file,
+        StringProperty q,
+        StringProperty sql) {
+
+    private static final SchemaProperties EMPTY = new SchemaProperties(null, null, null, null, null, null, null);
+
+    public static SchemaProperties empty() {
+        return EMPTY;
+    }
+
+    public static SchemaProperties appIdOnly() {
+        return new SchemaProperties(new StringProperty(), null, null, null, null, null, null);
+    }
+
+    public static SchemaProperties appIdAndApprovalToken() {
+        return new SchemaProperties(new StringProperty(), new StringProperty(), null, null, null, null, null);
+    }
+
+    public static SchemaProperties collectionAndApprovalToken() {
+        return new SchemaProperties(null, new StringProperty(), null, new StringProperty(), null, null, null);
+    }
+
+    public static SchemaProperties collectionAndQ() {
+        return new SchemaProperties(null, null, null, new StringProperty(), null, new StringProperty(), null);
+    }
+
+    public static SchemaProperties fileClassNameAndApprovalToken() {
+        return new SchemaProperties(null, new StringProperty(), new StringProperty(), null, new StringProperty(), null, null);
+    }
+
+    public static SchemaProperties sqlOnly() {
+        return new SchemaProperties(null, null, null, null, null, null, new StringProperty());
+    }
+}

--- a/mcp-gateway-core/src/main/java/io/github/vaquarkhan/aegis/core/jsonschema/SqlRequest.java
+++ b/mcp-gateway-core/src/main/java/io/github/vaquarkhan/aegis/core/jsonschema/SqlRequest.java
@@ -1,0 +1,7 @@
+package io.github.vaquarkhan.aegis.core.jsonschema;
+
+/**
+ * Request body for a SQL endpoint POST.
+ */
+public record SqlRequest(String sql) {
+}

--- a/mcp-gateway-core/src/main/java/io/github/vaquarkhan/aegis/core/jsonschema/StringProperty.java
+++ b/mcp-gateway-core/src/main/java/io/github/vaquarkhan/aegis/core/jsonschema/StringProperty.java
@@ -1,0 +1,10 @@
+package io.github.vaquarkhan.aegis.core.jsonschema;
+
+/**
+ * A JSON Schema property of type {@code "string"}.
+ */
+public record StringProperty(String type) {
+    public StringProperty() {
+        this("string");
+    }
+}

--- a/mcp-gateway-core/src/main/java/io/github/vaquarkhan/aegis/core/jsonschema/SubmitRequest.java
+++ b/mcp-gateway-core/src/main/java/io/github/vaquarkhan/aegis/core/jsonschema/SubmitRequest.java
@@ -1,0 +1,10 @@
+package io.github.vaquarkhan.aegis.core.jsonschema;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Request body for a Livy batch submission.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record SubmitRequest(String file, String className) {
+}

--- a/mcp-gateway-core/src/main/java/io/github/vaquarkhan/aegis/core/util/JacksonUtils.java
+++ b/mcp-gateway-core/src/main/java/io/github/vaquarkhan/aegis/core/util/JacksonUtils.java
@@ -1,0 +1,22 @@
+package io.github.vaquarkhan.aegis.core.util;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Shared Jackson {@link ObjectMapper} configured for JSON Schema serialization.
+ */
+public final class JacksonUtils {
+
+    private static final ObjectMapper MAPPER = JsonMapper.builder()
+            .changeDefaultPropertyInclusion(inc -> JsonInclude.Value.ALL_NON_NULL)
+            .build();
+
+    public static ObjectMapper getMapper() {
+        return MAPPER;
+    }
+
+    private JacksonUtils() {
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
     <slf4j.version>2.0.16</slf4j.version>
     <logback.version>1.5.12</logback.version>
     <junit.version>5.10.2</junit.version>
+    <jackson.version>3.1.5</jackson.version>
     <snakeyaml.version>2.2</snakeyaml.version>
     <kafka.version>3.8.0</kafka.version>
     <nimbus.jose.jwt.version>9.37.3</nimbus.jose.jwt.version>
@@ -139,6 +140,11 @@
         <groupId>io.github.vaquarkhan.aegis</groupId>
         <artifactId>mcp-gateway-core</artifactId>
         <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>tools.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${jackson.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Relates to #3 

Just shows how Jackson can be used for the JSON writes and in only 3 modules to show the design.

A lot of this is generated with Claude and I'm no expert in MCP so the data structures (Java records) may not be ideal. They can be iterated on.

#6 does the same thing and is probably a better way to go instead of us maintaining our own Java records for the JSON Schema data types.