### PR TITLE
throw IllegalStateException when JSON serialization fails

### DIFF
--- a/mcp-adapter-arrow/src/main/java/io/github/vaquarkhan/aegis/adapter/arrow/ArrowAdapter.java
+++ b/mcp-adapter-arrow/src/main/java/io/github/vaquarkhan/aegis/adapter/arrow/ArrowAdapter.java
@@ -89,7 +89,7 @@ public final class ArrowAdapter implements EngineAdapter {
         try {
             return new ToolDef(name, cls, desc, JSON_MAPPER.writeValueAsString(schema), backend);
         } catch (IOException e) {
-            throw new RuntimeException("Failed to serialize JsonSchema for tool: " + name, e);
+            throw new IllegalStateException("Failed to serialize JsonSchema for tool: " + name, e);
         }
     }
 

--- a/mcp-adapter-calcite/src/main/java/io/github/vaquarkhan/aegis/adapter/calcite/CalciteAdapter.java
+++ b/mcp-adapter-calcite/src/main/java/io/github/vaquarkhan/aegis/adapter/calcite/CalciteAdapter.java
@@ -94,7 +94,7 @@ public final class CalciteAdapter implements EngineAdapter {
             String json = JSON_MAPPER.writeValueAsString(schema);
             return new ToolDef(name, cls, desc, json, backend);
         } catch (IOException e) {
-            throw new RuntimeException("Failed to serialize JsonSchema for tool " + name, e);
+            throw new IllegalStateException("Failed to serialize JsonSchema for tool " + name, e);
         }
     }
 


### PR DESCRIPTION
there are 2 cases where RuntimeException is used while other adapters use IllegalStateException