### PR TITLE
test: add inputs test: validate paths and rejects traversal

### DIFF
--- a/mcp-gateway-core/src/test/java/io/github/vaquarkhan/aegis/core/InputsTest.java
+++ b/mcp-gateway-core/src/test/java/io/github/vaquarkhan/aegis/core/InputsTest.java
@@ -80,4 +80,12 @@ class InputsTest {
         assertEquals("\\u0001", Inputs.jsonEscape("\u0001"));
         assertEquals("", Inputs.jsonEscape(null));
     }
+
+    @Test
+    void validatesPathsAndRejectsTraversal() {
+        assertEquals("v1/status", Inputs.requirePath("v1/status"));
+        assertThrows(Inputs.InvalidInput.class, () -> Inputs.requirePath("a/../b"));
+        assertThrows(Inputs.InvalidInput.class, () -> Inputs.requirePath("../etc/passwd"));
+        assertThrows(Inputs.InvalidInput.class, () -> Inputs.requirePath(null));
+    }
 }


### PR DESCRIPTION
**Summary**: 

Enhances the existing InputsTest class in mcp-gateway-core by adding unit test coverage for Inputs.requirePath(...).

**Changes**:

Added validatesPathsAndRejectsTraversal() test case to InputsTest.java.

Asserts that requirePath accepts well-formed paths (e.g., "v1/status").

Asserts that requirePath throws Inputs.InvalidInput on path traversal sequences (e.g., "a/../b", "../etc/passwd") and null inputs.