### PR TITLE
Test: comprehensive testing of Hadoop adapter

### DIFF
--- a/mcp-adapter-hadoop/src/test/java/io/github/vaquarkhan/aegis/adapter/hadoop/HadoopAdapterTest.java
+++ b/mcp-adapter-hadoop/src/test/java/io/github/vaquarkhan/aegis/adapter/hadoop/HadoopAdapterTest.java
@@ -70,7 +70,6 @@ class HadoopAdapterTest {
         assertEquals("hadoop://status", resource.uri());
         assertEquals("hadoop-status", resource.name());
         assertEquals("application/json", resource.mimeType());
-        assertTrue(resource.direct());
     }
 
     @Test

--- a/mcp-adapter-hadoop/src/test/java/io/github/vaquarkhan/aegis/adapter/hadoop/HadoopAdapterTest.java
+++ b/mcp-adapter-hadoop/src/test/java/io/github/vaquarkhan/aegis/adapter/hadoop/HadoopAdapterTest.java
@@ -44,21 +44,14 @@ class HadoopAdapterTest {
         GatewayConfig cfg = GatewayConfig.builder().defaults().build();
         List<ToolDef> tools = adapter.tools(cfg);
 
-        assertEquals(4, tools.size());
-
         Map<String, ToolDef> toolMap = tools.stream()
                 .collect(Collectors.toMap(ToolDef::name, t -> t));
 
-        assertTrue(toolMap.containsKey("list_status"));
+        assertEquals(Set.of("list_status", "get_file_status", "mkdirs", "delete_path"), toolMap.keySet());
+
         assertEquals(ToolClass.READ, toolMap.get("list_status").cls());
-
-        assertTrue(toolMap.containsKey("get_file_status"));
         assertEquals(ToolClass.READ, toolMap.get("get_file_status").cls());
-
-        assertTrue(toolMap.containsKey("mkdirs"));
         assertEquals(ToolClass.MUTATE, toolMap.get("mkdirs").cls());
-
-        assertTrue(toolMap.containsKey("delete_path"));
         assertEquals(ToolClass.DESTRUCTIVE, toolMap.get("delete_path").cls());
 
         JsonNode schemaNode = JSON.readValue(toolMap.get("list_status").inputSchemaJson(), JsonNode.class);
@@ -88,7 +81,7 @@ class HadoopAdapterTest {
 
         GatewayConfig customConfig = GatewayConfig.builder()
                 .defaults()
-                .property("hadoop.url", "http://hdfs-nn.prod.internal:9870")
+                .adapterProperties(Map.of("hadoop.url", "http://hdfs-nn.prod.internal:9870"))
                 .build();
         Set<String> customHosts = adapter.egressAllowHosts(customConfig);
         assertEquals(Set.of("hdfs-nn.prod.internal"), customHosts);
@@ -98,7 +91,7 @@ class HadoopAdapterTest {
     void egressAllowHosts_handlesInvalidUriGracefully() {
         GatewayConfig invalidConfig = GatewayConfig.builder()
                 .defaults()
-                .property("hadoop.url", "ht tp://invalid uri")
+                .adapterProperties(Map.of("hadoop.url", "ht tp://invalid uri"))
                 .build();
         Set<String> hosts = adapter.egressAllowHosts(invalidConfig);
         assertTrue(hosts.isEmpty());
@@ -112,15 +105,17 @@ class HadoopAdapterTest {
         // HDFS_WEBHDFS_URL environment fallback
         GatewayConfig envCfg = GatewayConfig.builder()
                 .defaults()
-                .property("HDFS_WEBHDFS_URL", "http://fallback-nn:9870")
+                .adapterProperties(Map.of("HDFS_WEBHDFS_URL", "http://fallback-nn:9870"))
                 .build();
         assertEquals("http://fallback-nn:9870", HadoopAdapter.baseUrl(envCfg));
 
         // hadoop.url primary property override
         GatewayConfig priorityCfg = GatewayConfig.builder()
                 .defaults()
-                .property("HDFS_WEBHDFS_URL", "http://fallback-nn:9870")
-                .property("hadoop.url", "http://primary-nn:9870")
+                .adapterProperties(Map.of(
+                        "HDFS_WEBHDFS_URL", "http://fallback-nn:9870",
+                        "hadoop.url", "http://primary-nn:9870"
+                ))
                 .build();
         assertEquals("http://primary-nn:9870", HadoopAdapter.baseUrl(priorityCfg));
     }

--- a/mcp-adapter-hadoop/src/test/java/io/github/vaquarkhan/aegis/adapter/hadoop/HadoopAdapterTest.java
+++ b/mcp-adapter-hadoop/src/test/java/io/github/vaquarkhan/aegis/adapter/hadoop/HadoopAdapterTest.java
@@ -1,25 +1,127 @@
 package io.github.vaquarkhan.aegis.adapter.hadoop;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.vaquarkhan.aegis.core.config.GatewayConfig;
+import io.github.vaquarkhan.aegis.core.spi.ResourceDef;
+import io.github.vaquarkhan.aegis.core.spi.ToolClass;
 import io.github.vaquarkhan.aegis.core.spi.ToolDef;
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapperSupplier;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
 
-/** @author Viquar Khan */
+/**
+ * Unit tests for {@link HadoopAdapter}.
+ *
+ * @author Viquar Khan
+ */
 class HadoopAdapterTest {
 
+    private static final McpJsonMapper JSON = new JacksonMcpJsonMapperSupplier().get();
+    private HadoopAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+        adapter = new HadoopAdapter();
+    }
+
     @Test
-    void taxonomyAndTools() {
-        HadoopAdapter adapter = new HadoopAdapter();
+    void taxonomyAndMetadata() {
         assertEquals("hadoop", adapter.engineId());
         assertEquals("storage", adapter.taxonomyClass());
-        Set<String> names = adapter.tools(GatewayConfig.builder().defaults().build()).stream()
-                .map(ToolDef::name)
-                .collect(Collectors.toSet());
-        assertTrue(names.contains("list_status"));
+    }
+
+    @Test
+    void toolRegistrationAndPermissions() throws Exception {
+        GatewayConfig cfg = GatewayConfig.builder().defaults().build();
+        List<ToolDef> tools = adapter.tools(cfg);
+
+        assertEquals(4, tools.size());
+
+        Map<String, ToolDef> toolMap = tools.stream()
+                .collect(Collectors.toMap(ToolDef::name, t -> t));
+
+        assertTrue(toolMap.containsKey("list_status"));
+        assertEquals(ToolClass.READ, toolMap.get("list_status").cls());
+
+        assertTrue(toolMap.containsKey("get_file_status"));
+        assertEquals(ToolClass.READ, toolMap.get("get_file_status").cls());
+
+        assertTrue(toolMap.containsKey("mkdirs"));
+        assertEquals(ToolClass.MUTATE, toolMap.get("mkdirs").cls());
+
+        assertTrue(toolMap.containsKey("delete_path"));
+        assertEquals(ToolClass.DESTRUCTIVE, toolMap.get("delete_path").cls());
+
+        JsonNode schemaNode = JSON.readValue(toolMap.get("list_status").inputSchemaJson(), JsonNode.class);
+        assertEquals("object", schemaNode.get("type").asText());
+        assertNotNull(schemaNode.get("properties").get("path"));
+    }
+
+    @Test
+    void resourceRegistration() {
+        GatewayConfig cfg = GatewayConfig.builder().defaults().build();
+        List<ResourceDef> resources = adapter.resources(cfg);
+
+        assertEquals(1, resources.size());
+        ResourceDef resource = resources.get(0);
+
+        assertEquals("hadoop://status", resource.uri());
+        assertEquals("hadoop-status", resource.name());
+        assertEquals("application/json", resource.mimeType());
+        assertTrue(resource.direct());
+    }
+
+    @Test
+    void egressAllowHosts_defaultAndCustom() {
+        GatewayConfig defaultConfig = GatewayConfig.builder().defaults().build();
+        Set<String> defaultHosts = adapter.egressAllowHosts(defaultConfig);
+        assertEquals(Set.of("localhost"), defaultHosts);
+
+        GatewayConfig customConfig = GatewayConfig.builder()
+                .defaults()
+                .property("hadoop.url", "http://hdfs-nn.prod.internal:9870")
+                .build();
+        Set<String> customHosts = adapter.egressAllowHosts(customConfig);
+        assertEquals(Set.of("hdfs-nn.prod.internal"), customHosts);
+    }
+
+    @Test
+    void egressAllowHosts_handlesInvalidUriGracefully() {
+        GatewayConfig invalidConfig = GatewayConfig.builder()
+                .defaults()
+                .property("hadoop.url", "ht tp://invalid uri")
+                .build();
+        Set<String> hosts = adapter.egressAllowHosts(invalidConfig);
+        assertTrue(hosts.isEmpty());
+    }
+
+    @Test
+    void baseUrlResolutionHierarchy() {
+        // Default fallback
+        assertEquals("http://localhost:9870", HadoopAdapter.baseUrl(GatewayConfig.builder().defaults().build()));
+
+        // HDFS_WEBHDFS_URL environment fallback
+        GatewayConfig envCfg = GatewayConfig.builder()
+                .defaults()
+                .property("HDFS_WEBHDFS_URL", "http://fallback-nn:9870")
+                .build();
+        assertEquals("http://fallback-nn:9870", HadoopAdapter.baseUrl(envCfg));
+
+        // hadoop.url primary property override
+        GatewayConfig priorityCfg = GatewayConfig.builder()
+                .defaults()
+                .property("HDFS_WEBHDFS_URL", "http://fallback-nn:9870")
+                .property("hadoop.url", "http://primary-nn:9870")
+                .build();
+        assertEquals("http://primary-nn:9870", HadoopAdapter.baseUrl(priorityCfg));
     }
 }


### PR DESCRIPTION
### Summary

Adds unit tests for `HadoopAdapter` to cover engine metadata, tool permissions, resource definitions, configuration fallback, and egress host parsing.

### Changes

* **Metadata & Taxonomy:** Verifies `engineId` (`hadoop`) and `taxonomyClass` (`storage`).
* **Tool Permissions & Schema:** Asserts tool registration, input schema JSON structure, and security classifications (`READ`, `MUTATE`, `DESTRUCTIVE`).
* **Resource Registration:** Validates URI, MIME type, name, and direct access flags for `hadoop://status`.
* **Config & Egress Isolation:** Tests `baseUrl` override hierarchy (`hadoop.url` > `HDFS_WEBHDFS_URL` > default) and `egressAllowHosts` parsing (including malformed URIs).