### PR TITLE
docs: correct MCP Java SDK license in NOTICE to MIT

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -13,7 +13,7 @@ You may obtain a copy of the License at
 This product bundles or depends on third-party software licensed as follows.
 
 - Model Context Protocol Java SDK (io.modelcontextprotocol.sdk:mcp)
-  Apache License, Version 2.0
+  MIT License
 - Eclipse Jetty (org.eclipse.jetty.ee10:jetty-ee10-servlet)
   Apache License, Version 2.0 and Eclipse Public License, Version 2.0
 - SLF4J (org.slf4j:slf4j-api)


### PR DESCRIPTION
## Summary
- NOTICE listed the Model Context Protocol Java SDK as Apache-2.0. Maven Central records `io.modelcontextprotocol.sdk:mcp` 1.1.3 as MIT. This changes that single NOTICE line.

## Test plan
- [ ] Confirm NOTICE MCP SDK line reads MIT License
- [ ] No other NOTICE or source files changed
