### PR TITLE
feat(adapter): add YamlAdapterScanner and DeclarativeAdapterSpec for …

### DIFF
--- a/mcp-gateway-core/src/main/java/io/github/vaquarkhan/aegis/core/DeclarativeAdapterSpec.java
+++ b/mcp-gateway-core/src/main/java/io/github/vaquarkhan/aegis/core/DeclarativeAdapterSpec.java
@@ -1,0 +1,136 @@
+package io.github.vaquarkhan.aegis.core;
+
+
+import io.github.vaquarkhan.aegis.core.spi.ToolClass;
+
+import java.util.List;
+import java.util.Map;
+
+public final class DeclarativeAdapterSpec {
+
+    private final String version;
+    private final String engineId;
+    private final String taxonomyClass;
+    private final String description;
+    private final ConfigSpec configuration;
+    private final List<ToolSpec> tools;
+    private final List<ResourceSpec> resources;
+
+    public DeclarativeAdapterSpec(
+            String version,
+            String engineId,
+            String taxonomyClass,
+            String description,
+            ConfigSpec configuration,
+            List<ToolSpec> tools,
+            List<ResourceSpec> resources) {
+        this.version = version;
+        this.engineId = engineId;
+        this.taxonomyClass = taxonomyClass;
+        this.description = description;
+        this.configuration = configuration;
+        this.tools = tools == null ? List.of() : tools;
+        this.resources = resources == null ? List.of() : resources;
+    }
+
+    public String version() { return version; }
+    public String engineId() { return engineId; }
+    public String taxonomyClass() { return taxonomyClass; }
+    public String description() { return description; }
+    public ConfigSpec configuration() { return configuration; }
+    public List<ToolSpec> tools() { return tools; }
+    public List<ResourceSpec> resources() { return resources; }
+
+    public static final class ConfigSpec {
+        private final BaseUrlSpec baseUrl;
+
+        public ConfigSpec(BaseUrlSpec baseUrl) {
+            this.baseUrl = baseUrl;
+        }
+
+        public BaseUrlSpec baseUrl() { return baseUrl; }
+    }
+
+    public static final class BaseUrlSpec {
+        private final List<String> propertyCascade;
+        private final String defaultValue;
+
+        public BaseUrlSpec(List<String> propertyCascade, String defaultValue) {
+            this.propertyCascade = propertyCascade == null ? List.of() : propertyCascade;
+            this.defaultValue = defaultValue == null ? "" : defaultValue;
+        }
+
+        public List<String> propertyCascade() { return propertyCascade; }
+        public String defaultValue() { return defaultValue; }
+    }
+
+    public static final class ToolSpec {
+        private final String name;
+        private final ToolClass securityClass;
+        private final String description;
+        private final Map<String, Object> inputSchema;
+        private final EndpointSpec endpoint;
+
+        public ToolSpec(
+                String name,
+                ToolClass securityClass,
+                String description,
+                Map<String, Object> inputSchema,
+                EndpointSpec endpoint) {
+            this.name = name;
+            this.securityClass = securityClass;
+            this.description = description;
+            this.inputSchema = inputSchema == null ? Map.of() : inputSchema;
+            this.endpoint = endpoint;
+        }
+
+        public String name() { return name; }
+        public ToolClass securityClass() { return securityClass; }
+        public String description() { return description; }
+        public Map<String, Object> inputSchema() { return inputSchema; }
+        public EndpointSpec endpoint() { return endpoint; }
+    }
+
+    public static final class ResourceSpec {
+        private final String uri;
+        private final String name;
+        private final String mimeType;
+        private final boolean directRead;
+        private final EndpointSpec endpoint;
+
+        public ResourceSpec(
+                String uri,
+                String name,
+                String mimeType,
+                boolean directRead,
+                EndpointSpec endpoint) {
+            this.uri = uri;
+            this.name = name;
+            this.mimeType = mimeType;
+            this.directRead = directRead;
+            this.endpoint = endpoint;
+        }
+
+        public String uri() { return uri; }
+        public String name() { return name; }
+        public String mimeType() { return mimeType; }
+        public boolean directRead() { return directRead; }
+        public EndpointSpec endpoint() { return endpoint; }
+    }
+
+    public static final class EndpointSpec {
+        private final String method;
+        private final String path;
+        private final String body;
+
+        public EndpointSpec(String method, String path, String body) {
+            this.method = (method == null || method.isBlank()) ? "GET" : method;
+            this.path = (path == null || path.isBlank()) ? "/" : path;
+            this.body = body;
+        }
+
+        public String method() { return method; }
+        public String path() { return path; }
+        public String body() { return body; }
+    }
+}

--- a/mcp-gateway-core/src/main/java/io/github/vaquarkhan/aegis/core/YamlAdapterScanner.java
+++ b/mcp-gateway-core/src/main/java/io/github/vaquarkhan/aegis/core/YamlAdapterScanner.java
@@ -1,0 +1,217 @@
+package io.github.vaquarkhan.aegis.core;
+
+
+import io.github.vaquarkhan.aegis.core.spi.ToolClass;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.net.JarURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.stream.Stream;
+
+public final class YamlAdapterScanner {
+
+    private static final Logger LOG = LoggerFactory.getLogger(YamlAdapterScanner.class);
+    private static final String RESOURCE_DIR = "META-INF/aegis/adapters/";
+    private static final int MAX_ALIASES = 64;
+
+    /**
+     * Scans the classpath for YAML adapter specs and parses them into DeclarativeAdapterSpec objects.
+     */
+    public List<DeclarativeAdapterSpec> scanClasspathSpecs() {
+        List<DeclarativeAdapterSpec> specs = new ArrayList<>();
+        try {
+            ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+            Enumeration<URL> resources = classLoader.getResources(RESOURCE_DIR);
+
+            while (resources.hasMoreElements()) {
+                URL resourceUrl = resources.nextElement();
+                String protocol = resourceUrl.getProtocol();
+
+                if ("file".equals(protocol)) {
+                    scanFileSystem(Paths.get(resourceUrl.toURI()), specs);
+                } else if ("jar".equals(protocol)) {
+                    scanJarFile(resourceUrl, specs);
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("Error scanning YAML adapter specs from classpath", e);
+        }
+        return specs;
+    }
+
+    private void scanFileSystem(Path dirPath, List<DeclarativeAdapterSpec> specs) {
+        if (!Files.isDirectory(dirPath)) return;
+        try (Stream<Path> paths = Files.walk(dirPath, 1)) {
+            paths.filter(p -> p.toString().endsWith(".yaml") || p.toString().endsWith(".yml"))
+                    .forEach(file -> {
+                        try (InputStream is = Files.newInputStream(file)) {
+                            parseAndAdd(is, file.getFileName().toString(), specs);
+                        } catch (Exception e) {
+                            LOG.error("Failed to read adapter file: {}", file, e);
+                        }
+                    });
+        } catch (Exception e) {
+            LOG.error("Failed to read adapter directory: {}", dirPath, e);
+        }
+    }
+
+    private void scanJarFile(URL jarUrl, List<DeclarativeAdapterSpec> specs) {
+        try {
+            URLConnection conn = jarUrl.openConnection();
+            if (conn instanceof JarURLConnection jarConn) {
+                try (JarFile jarFile = jarConn.getJarFile()) {
+                    Enumeration<JarEntry> entries = jarFile.entries();
+                    while (entries.hasMoreElements()) {
+                        JarEntry entry = entries.nextElement();
+                        String name = entry.getName();
+                        if (name.startsWith(RESOURCE_DIR) && (name.endsWith(".yaml") || name.endsWith(".yml"))) {
+                            try (InputStream is = jarFile.getInputStream(entry)) {
+                                parseAndAdd(is, name, specs);
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("Failed to scan JAR file: {}", jarUrl, e);
+        }
+    }
+
+    private void parseAndAdd(InputStream is, String sourceName, List<DeclarativeAdapterSpec> specs) {
+        try (Reader reader = new InputStreamReader(is, StandardCharsets.UTF_8)) {
+            Yaml yaml = newYaml();
+            Object loaded = yaml.load(reader);
+            if (!(loaded instanceof Map<?, ?> root)) {
+                LOG.warn("Skipping {}: root is not a YAML mapping", sourceName);
+                return;
+            }
+
+            DeclarativeAdapterSpec spec = parseAdapterSpec(asMap(root));
+            specs.add(spec);
+            LOG.info("Loaded declarative adapter spec [{}] from {}", spec.engineId(), sourceName);
+        } catch (Exception e) {
+            LOG.error("Failed to parse YAML spec from {}", sourceName, e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private DeclarativeAdapterSpec parseAdapterSpec(Map<String, Object> root) {
+        String version = str(root.get("version"));
+        String engineId = str(root.get("engineId"));
+        String taxonomyClass = str(root.get("taxonomyClass"));
+        String description = str(root.get("description"));
+
+        // Configuration
+        DeclarativeAdapterSpec.ConfigSpec configSpec = null;
+        if (root.get("configuration") instanceof Map<?, ?> cfgMap) {
+            if (cfgMap.get("baseUrl") instanceof Map<?, ?> urlMap) {
+                List<String> cascade = (List<String>) urlMap.get("propertyCascade");
+                String defaultUrl = str(urlMap.get("default"));
+                configSpec = new DeclarativeAdapterSpec.ConfigSpec(
+                        new DeclarativeAdapterSpec.BaseUrlSpec(cascade, defaultUrl)
+                );
+            }
+        }
+
+        // Tools
+        List<DeclarativeAdapterSpec.ToolSpec> tools = new ArrayList<>();
+        if (root.get("tools") instanceof List<?> toolList) {
+            for (Object item : toolList) {
+                if (item instanceof Map<?, ?> t) {
+                    tools.add(new DeclarativeAdapterSpec.ToolSpec(
+                            str(t.get("name")),
+                            parseToolClass(t.get("securityClass")),
+                            str(t.get("description")),
+                            t.get("inputSchema") instanceof Map<?, ?> schema ? (Map<String, Object>) schema : Map.of(),
+                            parseEndpoint(t.get("endpoint"))
+                    ));
+                }
+            }
+        }
+
+        // Resources
+        List<DeclarativeAdapterSpec.ResourceSpec> resources = new ArrayList<>();
+        if (root.get("resources") instanceof List<?> resList) {
+            for (Object item : resList) {
+                if (item instanceof Map<?, ?> r) {
+                    resources.add(new DeclarativeAdapterSpec.ResourceSpec(
+                            str(r.get("uri")),
+                            str(r.get("name")),
+                            str(r.get("mimeType")),
+                            bool(r.get("directRead"), false),
+                            parseEndpoint(r.get("endpoint"))
+                    ));
+                }
+            }
+        }
+
+        return new DeclarativeAdapterSpec(version, engineId, taxonomyClass, description, configSpec, tools, resources);
+    }
+
+    private DeclarativeAdapterSpec.EndpointSpec parseEndpoint(Object raw) {
+        if (!(raw instanceof Map<?, ?> e)) {
+            return new DeclarativeAdapterSpec.EndpointSpec("GET", "/", null);
+        }
+        return new DeclarativeAdapterSpec.EndpointSpec(
+                str(e.get("method")),
+                str(e.get("path")),
+                str(e.get("body"))
+        );
+    }
+
+    private Yaml newYaml() {
+        LoaderOptions options = new LoaderOptions();
+        options.setAllowDuplicateKeys(false);
+        options.setMaxAliasesForCollections(MAX_ALIASES);
+        return new Yaml(new SafeConstructor(options));
+    }
+
+    private Map<String, Object> asMap(Map<?, ?> map) {
+        Map<String, Object> typed = new LinkedHashMap<>();
+        map.forEach((k, v) -> typed.put(String.valueOf(k), v));
+        return typed;
+    }
+
+    private String str(Object v) {
+        if (v == null) return null;
+        String s = String.valueOf(v).trim();
+        return s.isEmpty() ? null : s;
+    }
+
+    private boolean bool(Object v, boolean fallback) {
+        if (v == null) return fallback;
+        if (v instanceof Boolean b) return b;
+        return Boolean.parseBoolean(String.valueOf(v).trim());
+    }
+
+    private ToolClass parseToolClass(Object v) {
+        String s = str(v);
+        if (s == null) return null;
+        try {
+            return ToolClass.valueOf(s.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            LOG.warn("Unknown ToolClass value: {}", s);
+            return null;
+        }
+    }
+}

--- a/mcp-gateway-core/src/test/java/io/github/vaquarkhan/aegis/core/YamlAdapterScannerTest.java
+++ b/mcp-gateway-core/src/test/java/io/github/vaquarkhan/aegis/core/YamlAdapterScannerTest.java
@@ -1,0 +1,75 @@
+package io.github.vaquarkhan.aegis.core;
+
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class YamlAdapterScannerTest {
+
+    private YamlAdapterScanner scanner;
+
+    @BeforeEach
+    void setUp() {
+        scanner = new YamlAdapterScanner();
+    }
+
+    @Test
+    @DisplayName("Should scan classpath and locate mock-storage.yaml")
+    void testScanClasspathFindsAdapter() {
+        List<DeclarativeAdapterSpec> specs = scanner.scanClasspathSpecs();
+
+        assertNotNull(specs, "Scanned spec list should not be null");
+        assertFalse(specs.isEmpty(), "Scanner should find at least one adapter spec on test classpath");
+
+        boolean foundMock = specs.stream()
+                .anyMatch(spec -> "mock-storage".equals(spec.engineId()));
+
+        assertTrue(foundMock, "Scanner should discover 'mock-storage' from test resources");
+    }
+
+    @Test
+    @DisplayName("Should correctly map all fields from mock-storage.yaml into DeclarativeAdapterSpec")
+    void testAdapterSpecFieldMapping() {
+        List<DeclarativeAdapterSpec> specs = scanner.scanClasspathSpecs();
+
+        DeclarativeAdapterSpec mockSpec = specs.stream()
+                .filter(spec -> "mock-storage".equals(spec.engineId()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Mock storage spec not found"));
+
+
+        assertEquals("1.0", mockSpec.version());
+        assertEquals("mock-storage", mockSpec.engineId());
+        assertEquals("storage", mockSpec.taxonomyClass());
+        assertEquals("Mock storage engine adapter for unit testing scanner", mockSpec.description());
+
+
+        assertNotNull(mockSpec.configuration());
+        assertNotNull(mockSpec.configuration().baseUrl());
+        assertEquals("http://localhost:8080", mockSpec.configuration().baseUrl().defaultValue());
+        assertEquals(List.of("mock.url", "MOCK_STORAGE_URL"), mockSpec.configuration().baseUrl().propertyCascade());
+
+
+        assertEquals(1, mockSpec.tools().size());
+        DeclarativeAdapterSpec.ToolSpec tool = mockSpec.tools().get(0);
+        assertEquals("list_files", tool.name());
+        assertEquals("Lists files in directory", tool.description());
+        assertEquals("GET", tool.endpoint().method());
+        assertEquals("/list${input.path}", tool.endpoint().path());
+
+
+        assertEquals(1, mockSpec.resources().size());
+        DeclarativeAdapterSpec.ResourceSpec res = mockSpec.resources().get(0);
+        assertEquals("mock://status", res.uri());
+        assertEquals("Mock Status", res.name());
+        assertEquals("application/json", res.mimeType());
+        assertTrue(res.directRead());
+        assertEquals("GET", res.endpoint().method());
+        assertEquals("/status", res.endpoint().path());
+    }
+}

--- a/mcp-gateway-core/src/test/resources/META-INF/aegis/adapters/mock-storage.yaml
+++ b/mcp-gateway-core/src/test/resources/META-INF/aegis/adapters/mock-storage.yaml
@@ -1,0 +1,30 @@
+version: "1.0"
+engineId: "mock-storage"
+taxonomyClass: "storage"
+description: "Mock storage engine adapter for unit testing scanner"
+configuration:
+  baseUrl:
+    propertyCascade:
+      - "mock.url"
+      - "MOCK_STORAGE_URL"
+    default: "http://localhost:8080"
+tools:
+  - name: "list_files"
+    securityClass: "READ_ONLY"
+    description: "Lists files in directory"
+    inputSchema:
+      type: "object"
+      properties:
+        path:
+          type: "string"
+    endpoint:
+      method: "GET"
+      path: "/list${input.path}"
+resources:
+  - uri: "mock://status"
+    name: "Mock Status"
+    mimeType: "application/json"
+    directRead: true
+    endpoint:
+      method: "GET"
+      path: "/status"


### PR DESCRIPTION
**Summary**
Introduces the foundational data model (DeclarativeAdapterSpec) and classpath scanner (YamlAdapterScanner) to support declarative, YAML-based engine adapters. This PR covers the parsing and discovery infrastructure (Part 1); runtime execution via YamlEngineAdapter and GenericHttpExecutor will follow in Part 2.

**Key Changes**
DeclarativeAdapterSpec: Immutable specification model representing tools, resources, endpoints, and configuration cascades for declarative adapters.

YamlAdapterScanner: Classpath discovery engine that scans META-INF/aegis/adapters/ for .yaml/.yml definitions. Uses SnakeYAML's SafeConstructor with bounded alias execution to prevent vulnerabilities.

YamlAdapterScannerTest: Unit test suite validating classpath scanning, mapping logic, and endpoint field assignments against test resource definitions.