### PR TITLE
fix(flink): correct fail-closed env var name in requireJarPath error message

### DIFF
--- a/mcp-adapter-flink/src/main/java/io/github/vaquarkhan/aegis/adapter/flink/FlinkToolFactory.java
+++ b/mcp-adapter-flink/src/main/java/io/github/vaquarkhan/aegis/adapter/flink/FlinkToolFactory.java
@@ -175,7 +175,7 @@ public final class FlinkToolFactory {
                 "/jobs/" + jobId(ctx) + "/rescaling?parallelism=" + Inputs.requireInt(arg(ctx, "parallelism")),
                 "{}"));
         b.put("upload_jar", ctx ->
-                flink.uploadJar(Inputs.requireJarPath(arg(ctx, "path"), FlinkConfigKeys.jarUploadAllowDirs(cfg))));
+                flink.uploadJar(Inputs.requireJarPath(arg(ctx, "path"), FlinkConfigKeys.jarUploadAllowDirs(cfg),"MCP_FLINK_JAR_UPLOAD_ALLOW_DIRS")));
 
         b.put("cancel_job", ctx -> flink.patch("/jobs/" + jobId(ctx), "{\"mode\":\"cancel\"}"));
         b.put("stop_job", ctx -> flink.post("/jobs/" + jobId(ctx) + "/stop", targetDirectoryBody(ctx)));

--- a/mcp-gateway-core/src/main/java/io/github/vaquarkhan/aegis/core/util/Inputs.java
+++ b/mcp-gateway-core/src/main/java/io/github/vaquarkhan/aegis/core/util/Inputs.java
@@ -110,7 +110,10 @@ public final class Inputs {
      * directories. An empty allow list rejects everything, which keeps artifact upload fail-closed
      * until an operator opts in.
      */
-    public static Path requireJarPath(String path, Set<String> allowDirs) {
+    public static Path requireJarPath(String path, Set<String> allowDirs, String envVarName) {
+        if (allowDirs == null || allowDirs.isEmpty()) {
+            throw new InvalidInput("jar upload directories not configured (" + envVarName + ")");
+        }
         if (path == null || path.isBlank()) {
             throw new InvalidInput("jar path required");
         }

--- a/mcp-gateway-core/src/test/java/io/github/vaquarkhan/aegis/core/InputsTest.java
+++ b/mcp-gateway-core/src/test/java/io/github/vaquarkhan/aegis/core/InputsTest.java
@@ -2,8 +2,11 @@ package io.github.vaquarkhan.aegis.core;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.vaquarkhan.aegis.core.util.Inputs;
+
+import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
@@ -66,9 +69,18 @@ class InputsTest {
 
     @Test
     void jarUploadFailsClosedWithoutAllowList() {
-        assertThrows(Inputs.InvalidInput.class, () -> Inputs.requireJarPath("/tmp/app.jar", Set.of()));
-        assertThrows(Inputs.InvalidInput.class, () -> Inputs.requireJarPath("/tmp/app.jar", null));
-        assertThrows(Inputs.InvalidInput.class, () -> Inputs.requireJarPath(null, Set.of("/tmp")));
+        assertThrows(Inputs.InvalidInput.class, () -> Inputs.requireJarPath("/tmp/app.jar", Set.of(), ""));
+        assertThrows(Inputs.InvalidInput.class, () -> Inputs.requireJarPath("/tmp/app.jar", null,""));
+        assertThrows(Inputs.InvalidInput.class, () -> Inputs.requireJarPath(null, Set.of("/tmp"),""));
+    }
+
+    @Test
+    void testRequireJarPathThrowsWhenUnconfigured() {
+        Inputs.InvalidInput ex = assertThrows(
+                Inputs.InvalidInput.class,
+                () -> Inputs.requireJarPath("/path/to/app.jar", Set.of(), "MCP_FLINK_JAR_UPLOAD_ALLOW_DIRS")
+        );
+        assertTrue(ex.getMessage().contains("MCP_FLINK_JAR_UPLOAD_ALLOW_DIRS"));
     }
 
     @Test


### PR DESCRIPTION
related https://github.com/vaquarkhan/aegis-mcp-gateway/issues/23

**Changes**
_Parameterize requireJarPath_: Added an envVarName parameter to Inputs.requireJarPath(...) so callers specify their actual configuration variable name in the fail-closed exception message.

_Update Flink Tool Factory_: Updated the upload_jar tool definition to pass "MCP_FLINK_JAR_UPLOAD_ALLOW_DIRS".

_Expand Test Coverage_: Extended InputsTest to verify that the exception message explicitly names the passed environment variable.