### PR TITLE
fix(flink): name correct env var in upload_jar error message

### DIFF
--- a/mcp-adapter-flink/src/main/java/io/github/vaquarkhan/aegis/adapter/flink/FlinkConfigKeys.java
+++ b/mcp-adapter-flink/src/main/java/io/github/vaquarkhan/aegis/adapter/flink/FlinkConfigKeys.java
@@ -72,7 +72,14 @@ public final class FlinkConfigKeys {
      * the secure default when the operator has not configured any directory.
      */
     public static Set<String> jarUploadAllowDirs(GatewayConfig cfg) {
-        return parseCsv(property(cfg, JAR_UPLOAD_ALLOW_DIRS_YAML, JAR_UPLOAD_ALLOW_DIRS, null));
+        if (cfg == null) {
+            return Set.of();
+        }
+        Set<String> flinkDirs = parseCsv(property(cfg, JAR_UPLOAD_ALLOW_DIRS_YAML, JAR_UPLOAD_ALLOW_DIRS, null));
+        if (!flinkDirs.isEmpty()) {
+            return flinkDirs;
+        }
+        return cfg.jarUploadAllowDirs();
     }
 
     /** Hosts this adapter is allowed to reach, for the core egress guard. */

--- a/mcp-adapter-flink/src/main/java/io/github/vaquarkhan/aegis/adapter/flink/FlinkToolFactory.java
+++ b/mcp-adapter-flink/src/main/java/io/github/vaquarkhan/aegis/adapter/flink/FlinkToolFactory.java
@@ -175,7 +175,7 @@ public final class FlinkToolFactory {
                 "/jobs/" + jobId(ctx) + "/rescaling?parallelism=" + Inputs.requireInt(arg(ctx, "parallelism")),
                 "{}"));
         b.put("upload_jar", ctx ->
-                flink.uploadJar(Inputs.requireJarPath(arg(ctx, "path"), FlinkConfigKeys.jarUploadAllowDirs(cfg))));
+                flink.uploadJar(Inputs.requireJarPath(arg(ctx, "path"), FlinkConfigKeys.jarUploadAllowDirs(cfg),"MCP_FLINK_JAR_UPLOAD_ALLOW_DIRS / MCP_GW_JAR_UPLOAD_ALLOW_DIRS")));
 
         b.put("cancel_job", ctx -> flink.patch("/jobs/" + jobId(ctx), "{\"mode\":\"cancel\"}"));
         b.put("stop_job", ctx -> flink.post("/jobs/" + jobId(ctx) + "/stop", targetDirectoryBody(ctx)));

--- a/mcp-adapter-flink/src/test/java/io/github/vaquarkhan/aegis/adapter/flink/FlinkAdapterTest.java
+++ b/mcp-adapter-flink/src/test/java/io/github/vaquarkhan/aegis/adapter/flink/FlinkAdapterTest.java
@@ -261,4 +261,13 @@ class FlinkAdapterTest {
         assertEquals("http://from-yaml:8081", FlinkConfigKeys.restUrl(cfg));
         assertEquals(Set.of("/opt/jars", "/srv/jars"), FlinkConfigKeys.jarUploadAllowDirs(cfg));
     }
+
+    @Test
+    void uploadJarIsRejectedWhenNoDirectoryIsAllowListed() {
+        ToolDef upload = tool(new FlinkAdapter().tools(config()), "upload_jar");
+        Inputs.InvalidInput ex = assertThrows(Inputs.InvalidInput.class,
+                () -> upload.backend().apply(ctx("upload_jar", ToolClass.MUTATE, Map.of("path", "/tmp/someJar.jar"))));
+        assertTrue(ex.getMessage().contains("MCP_FLINK_JAR_UPLOAD_ALLOW_DIRS"),
+                "exception message should state the allowed dir env var name");
+    }
 }

--- a/mcp-adapter-flink/src/test/java/io/github/vaquarkhan/aegis/adapter/flink/FlinkAdapterTest.java
+++ b/mcp-adapter-flink/src/test/java/io/github/vaquarkhan/aegis/adapter/flink/FlinkAdapterTest.java
@@ -166,13 +166,6 @@ class FlinkAdapterTest {
     }
 
     @Test
-    void uploadJarIsRejectedWhenNoDirectoryIsAllowListed() {
-        ToolDef upload = tool(new FlinkAdapter().tools(config()), "upload_jar");
-        assertThrows(Inputs.InvalidInput.class,
-                () -> upload.backend().apply(ctx("upload_jar", ToolClass.MUTATE, Map.of("path", "/tmp/any.jar"))));
-    }
-
-    @Test
     void readOnlySqlToolRejectsMutatingStatements() {
         ToolDef sql = tool(new FlinkAdapter().tools(config()), "run_sql_readonly");
         assertThrows(Inputs.InvalidInput.class,

--- a/mcp-gateway-core/src/main/java/io/github/vaquarkhan/aegis/core/util/Inputs.java
+++ b/mcp-gateway-core/src/main/java/io/github/vaquarkhan/aegis/core/util/Inputs.java
@@ -110,7 +110,10 @@ public final class Inputs {
      * directories. An empty allow list rejects everything, which keeps artifact upload fail-closed
      * until an operator opts in.
      */
-    public static Path requireJarPath(String path, Set<String> allowDirs) {
+    public static Path requireJarPath(String path, Set<String> allowDirs, String envVarName) {
+        if (allowDirs == null || allowDirs.isEmpty()) {
+            throw new InvalidInput("jar upload directories not configured (" + envVarName + ")");
+        }
         if (path == null || path.isBlank()) {
             throw new InvalidInput("jar path required");
         }

--- a/mcp-gateway-core/src/test/java/io/github/vaquarkhan/aegis/core/InputsTest.java
+++ b/mcp-gateway-core/src/test/java/io/github/vaquarkhan/aegis/core/InputsTest.java
@@ -66,9 +66,9 @@ class InputsTest {
 
     @Test
     void jarUploadFailsClosedWithoutAllowList() {
-        assertThrows(Inputs.InvalidInput.class, () -> Inputs.requireJarPath("/tmp/app.jar", Set.of()));
-        assertThrows(Inputs.InvalidInput.class, () -> Inputs.requireJarPath("/tmp/app.jar", null));
-        assertThrows(Inputs.InvalidInput.class, () -> Inputs.requireJarPath(null, Set.of("/tmp")));
+        assertThrows(Inputs.InvalidInput.class, () -> Inputs.requireJarPath("/tmp/app.jar", Set.of(),""));
+        assertThrows(Inputs.InvalidInput.class, () -> Inputs.requireJarPath("/tmp/app.jar", null,""));
+        assertThrows(Inputs.InvalidInput.class, () -> Inputs.requireJarPath(null, Set.of("/tmp"),""));
     }
 
     @Test


### PR DESCRIPTION
https://github.com/vaquarkhan/aegis-mcp-gateway/issues/24

Main changes

FlinkToolFactory.java: Updated the upload_jar backend definition to pass "MCP_FLINK_JAR_UPLOAD_ALLOW_DIRS".