### PR TITLE
docs(flink): adapter flink wrap paragraph for under 100

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -63,9 +63,10 @@ resources a destructive tool binds to most often. Give `ops-bot` the job ids it 
 and nothing else.
 
 `upload_jar` and `run_jar` are the sharpest tools in the project. Set
-`MCP_GW_JAR_UPLOAD_ALLOW_DIRS` so a jar can only come from a directory you control, and keep the
-jar allow list narrow. Running an arbitrary jar on a Flink cluster is remote code execution by
-design; the allow lists are what make it an operation rather than an exploit.
+`MCP_GW_JAR_UPLOAD_ALLOW_DIRS` so a jar can only come from a directory
+you control, and keep the jar allow list narrow. Running an arbitrary
+jar on a Flink cluster is remote code execution by design; the allow
+lists are what make it an operation rather than an exploit.
 
 ## Apache Kafka
 


### PR DESCRIPTION
Related https://github.com/vaquarkhan/aegis-mcp-gateway/issues/25
**Summary**
Re-wraps long lines in adapters.md (Flink) to conform to the standard ~100-column line width requirement. 